### PR TITLE
fix: typo in Pkcs11Uri when checking scheme name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = "1"
 log = "0.4.11"
 percent-encoding = "2.1.0"
 pkcs11 = "0.5.0"
-uriparse = "0.6.3"
+uriparse = "0.6.4"
 # uriparse = { git = "https://github.com/sgodwincs/uriparse-rs", rev = "82de33ab5685c71810e61ba376cc637f26f2f182" }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,8 +205,7 @@ impl Pkcs11Uri {
         let uri = uriparse::URIReference::try_from(uri_string.as_str())?;
         // dbg!(&uri);
 
-        // if uri.scheme() != Some(&uriparse::Scheme::PKCS11) {
-        if uri.scheme() != Some(&uriparse::Scheme::PKCKS11) {
+        if uri.scheme() != Some(&uriparse::Scheme::PKCS11) {
             return Err(anyhow!("URI should have PKCS11 scheme"));
         }
         if uri.authority().is_some() {


### PR DESCRIPTION
This change is meant to fix the following error when running `cargo clippy`:

```
error[E0599]: no variant or associated item named `PKCKS11` found for enum `uriparse::Scheme` in the current scope
   --> src/lib.rs:209:52
    |
209 |         if uri.scheme() != Some(&uriparse::Scheme::PKCKS11) {
    |                                                    ^^^^^^^
    |                                                    |
    |                                                    variant or associated item not found in `uriparse::Scheme<'_>`
    |                                                    help: there is a variant with a similar name: `PKCS11`

```

Not sure why that typo is there, from the comment it looks like it might've been intentional.

I've started looking into this because `cargo install solo2` was failing to compile with the same error and I see the maintainer of this repo is a contributor to [solokeys/solo2-cli](https://github.com/solokeys/solo2-cli) as well.

Rust version tested with:
```
% rustc -V -v
rustc 1.59.0 (9d1b2106e 2022-02-23)
binary: rustc
commit-hash: 9d1b2106e23b1abd32fce1f17267604a5102f57a
commit-date: 2022-02-23
host: aarch64-apple-darwin
release: 1.59.0
LLVM version: 13.0.0
```