### PR TITLE
handle empty query segment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,10 +222,14 @@ impl Pkcs11Uri {
         let path_attributes = PathAttributes::try_from(segment).unwrap();
 
         // 3. parse Query Attributes
+        let mut query_attributes = QueryAttributes::default();
         let query = uri.query().map(|query| query.as_str()).unwrap_or("");
         debug!("query: {}", query);
-        let query_attributes = QueryAttributes::try_from(query).unwrap();
 
+        if !query.is_empty() {
+            query_attributes = QueryAttributes::try_from(query).unwrap();
+        }
+        
         // 4. wrap up
         let parsed_uri = Pkcs11Uri {
             path_attributes,


### PR DESCRIPTION
currently the Pkcs11Uri::try_from() fail to parse URI that do not have a query part, which is not mandatory segment according RFC 7512